### PR TITLE
Fix reverse proxy for elasticsearch

### DIFF
--- a/templates/nginx-client.conf
+++ b/templates/nginx-client.conf
@@ -29,7 +29,7 @@ http {
       include /etc/nginx/mime.types;
     }
 
-    location /es {
+    location /es/ {
       proxy_pass http://elasticsearch;
       rewrite ^/es(.*) $1 break;
     }


### PR DESCRIPTION
Reverse proxy for elastic search should end with '/' because it conflicts with kibana endpoint 'es_admin'