### PR TITLE
Fix path to templates

### DIFF
--- a/terraform-aws/client.tf
+++ b/terraform-aws/client.tf
@@ -1,5 +1,5 @@
 data "template_file" "client_userdata_script" {
-  template = "${file("${path.root}/../templates/user_data.sh")}"
+  template = "${file("${path.module}/../templates/user_data.sh")}"
 
   vars {
     cloud_provider          = "aws"

--- a/terraform-aws/datas.tf
+++ b/terraform-aws/datas.tf
@@ -1,5 +1,5 @@
 data "template_file" "data_userdata_script" {
-  template = "${file("${path.root}/../templates/user_data.sh")}"
+  template = "${file("${path.module}/../templates/user_data.sh")}"
 
   vars {
     cloud_provider          = "aws"

--- a/terraform-aws/iam.tf
+++ b/terraform-aws/iam.tf
@@ -1,11 +1,11 @@
 resource "aws_iam_role" "elasticsearch" {
   name               = "${var.es_cluster}-elasticsearch-discovery-role"
-  assume_role_policy = "${file("${path.root}/../templates/ec2-role-trust-policy.json")}"
+  assume_role_policy = "${file("${path.module}/../templates/ec2-role-trust-policy.json")}"
 }
 
 resource "aws_iam_role_policy" "elasticsearch" {
   name     = "${var.es_cluster}-elasticsearch-discovery-policy"
-  policy   = "${file("${path.root}/../templates/ec2-allow-describe-instances.json")}"
+  policy   = "${file("${path.module}/../templates/ec2-allow-describe-instances.json")}"
   role     = "${aws_iam_role.elasticsearch.id}"
 }
 

--- a/terraform-aws/masters.tf
+++ b/terraform-aws/masters.tf
@@ -1,5 +1,5 @@
 data "template_file" "master_userdata_script" {
-  template = "${file("${path.root}/../templates/user_data.sh")}"
+  template = "${file("${path.module}/../templates/user_data.sh")}"
 
   vars {
     cloud_provider          = "aws"

--- a/terraform-aws/single-node.tf
+++ b/terraform-aws/single-node.tf
@@ -1,5 +1,5 @@
 data "template_file" "single_node_userdata_script" {
-  template = "${file("${path.root}/../templates/user_data.sh")}"
+  template = "${file("${path.module}/../templates/user_data.sh")}"
 
   vars {
     cloud_provider          = "aws"


### PR DESCRIPTION
I tried to use it as a module
```
module "elk" {
  es_cluster       =  "test"
  source           = "https://github.com/synhershko/elasticsearch-cloud-deploy//terraform-aws"
...
}
```
and got a lots of errors like these
```
Error: module.elk.data.template_file.client_userdata_script: 1 error(s) occurred:
* module.elk.data.template_file.client_userdata_script: file: open /home/shine/Documents/fasten/tf-us-core-prod/elk-deadline/../templates/user_data.sh: no such file or directory in:
${file("${path.root}/../templates/user_data.sh")}
```
with those changes the errors go away