### PR TITLE
Fix heap size config

### DIFF
--- a/templates/user_data.sh
+++ b/templates/user_data.sh
@@ -72,8 +72,8 @@ EOF
 # Setup heap size and memory locking
 sudo sed -i 's/#MAX_LOCKED_MEMORY=.*$/MAX_LOCKED_MEMORY=unlimited/' /etc/init.d/elasticsearch
 sudo sed -i 's/#MAX_LOCKED_MEMORY=.*$/MAX_LOCKED_MEMORY=unlimited/' /etc/default/elasticsearch
-sudo sed -i "s/^-Xms2g/-Xms${heap_size}/" /etc/elasticsearch/jvm.options
-sudo sed -i "s/^-Xmx2g/-Xmx${heap_size}/" /etc/elasticsearch/jvm.options
+sudo sed -i "s/^-Xms.*/-Xms${heap_size}/" /etc/elasticsearch/jvm.options
+sudo sed -i "s/^-Xmx.*/-Xmx${heap_size}/" /etc/elasticsearch/jvm.options
 
 # Storage
 sudo mkdir -p ${elasticsearch_logs_dir}


### PR DESCRIPTION
I was setting up ES 6.2.3 and initial config had 1g value (instead of expected 2g) so the heap configuration didn't work. There are a lot of ways to match and replace but I chose ``.*`` so it works with all sorts of possible values like ``512mb``, ``16g`` without overcomplicating the regexp. Let me know if you want to use a different matcher.