### PR TITLE
Change EBS type from standard to gp2

### DIFF
--- a/terraform-aws/datas.tf
+++ b/terraform-aws/datas.tf
@@ -38,6 +38,7 @@ resource "aws_launch_configuration" "data" {
   }
 
   ebs_block_device {
+    volume_type = "gp2"
     device_name = "/dev/xvdh"
     volume_size = "${var.elasticsearch_volume_size}"
     encrypted = "${var.volume_encryption}"


### PR DESCRIPTION
Default is ``standard``. It is previous generation EBS volume type. I think almost everyone will want ``gp2`` or ``io1``.