### PR TITLE
Fix errors with Packer v1.2.4

### DIFF
--- a/packer/elasticsearch6-node.packer.json
+++ b/packer/elasticsearch6-node.packer.json
@@ -26,7 +26,7 @@
         "ImageType": "elasticsearch6-packer-image"
       },
       "spot_price_auto_product": "Linux/UNIX (Amazon VPC)",
-      "ena_support": true
+      "spot_price": "auto"
     },
     {
       "type": "azure-arm",

--- a/packer/kibana6-node.packer.json
+++ b/packer/kibana6-node.packer.json
@@ -24,12 +24,12 @@
         "most_recent": true
       },
       "spot_price_auto_product": "Linux/UNIX (Amazon VPC)",
+      "spot_price": "auto",
       "ssh_timeout": "10m",
       "ssh_username": "ubuntu",
       "tags": {
         "ImageType": "kibana6-packer-image"
-      },
-      "ena_support": true
+      }
     },
     {
       "type": "azure-arm",


### PR DESCRIPTION
This PR fixes:
* spot_price should be set to auto when spot_price_auto_product is specified
* Spot instances do not support modification, which is required when either `ena_support` or `sriov_support` are set. Please ensure you use an AMI that already has either SR-IOV or ENA enabled.
