### PR TITLE
Add lb_port variable

### DIFF
--- a/terraform-aws/main.tf
+++ b/terraform-aws/main.tf
@@ -114,7 +114,7 @@ resource "aws_elb" "es_client_lb" {
   listener {
     instance_port     = 8080
     instance_protocol = "http"
-    lb_port           = 80
+    lb_port           = "${var.lb_port}"
     lb_protocol       = "http"
   }
 

--- a/terraform-aws/variables.tf
+++ b/terraform-aws/variables.tf
@@ -114,3 +114,8 @@ variable "ebs_optimized" {
   description = "Whether data instances are EBS optimized or not"
   default = "true"
 }
+
+variable "lb_port" {
+  description = "The port the load balancer should listen on for API requests."
+  default     = 80
+}


### PR DESCRIPTION
This will allow users to override port for backward compatibility.  
It's needed because changing lb_port requires a lot of stuff to be reconfigured and sometimes it's not possible without downtime.