### PR TITLE
Elasticsearch plugin 'discovery-azure-classic' is deprecated.

### DIFF
--- a/packer/install-cloud-plugin.sh
+++ b/packer/install-cloud-plugin.sh
@@ -11,7 +11,6 @@ if [[ -f /sys/hypervisor/uuid && `head -c 3 /sys/hypervisor/uuid` == "ec2" ]]; t
 elif `grep -q unknown-245 /var/lib/dhcp/dhclient.eth0.leases`; then
   # install Azure-specific plugins only if running on Azure
   sudo bin/elasticsearch-plugin install --batch repository-azure
-  sudo bin/elasticsearch-plugin install --batch discovery-azure-classic
 elif (sudo dmidecode -s system-product-name | grep -q "Google Compute Engine"); then
   # install Google Compute specific plugins only if running on GCP
   sudo bin/elasticsearch-plugin install --batch discovery-gce


### PR DESCRIPTION
Plugin deprecated since Elasticsearch 5.x.

https://www.elastic.co/guide/en/elasticsearch/plugins/master/discovery-azure-classic.html