### PR TITLE
Kibana 6.x contains x-pack by default.

### DIFF
--- a/packer/install-kibana6.sh
+++ b/packer/install-kibana6.sh
@@ -14,10 +14,6 @@ else
     apt-get install kibana=$ES_VERSION
 fi
 
-cd /usr/share/kibana/
-bin/kibana-plugin install x-pack
-chown kibana:kibana * -R
-
 # This needs to be here explicitly because of a long first-initialization time of Kibana
 systemctl daemon-reload
 systemctl enable kibana.service


### PR DESCRIPTION
There is no longer need to install it as it is already present.

https://www.elastic.co/guide/en/elastic-stack-overview/current/installing-xpack.html